### PR TITLE
feat: build zig from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,17 @@ probably won't have to. If you're on Windows or MacOS, see the
 ### Prerequisites
 
 - A POSIX-compliant shell
+- [GNU coreutils](https://www.gnu.org/software/coreutils)
 - [curl](https://curl.se/download.html)
 - [jq](https://jqlang.github.io/jq/)
-- tar
+- GNU tar
 - unzip
+
+If you're building from source (`zvm install --src`), you'll need the
+following dependencies, in addition to those listed above:
+- [cmake](https://cmake.org) (version 3.15 or newer)
+- [git](https://git-scm.org)
+- GNU sed
 
 ### Usage
 
@@ -126,27 +133,15 @@ override it if you need to.
 
 ### Windows
 
-Supported via various Linux subsystems (git-bash, WSL, etc.).
-
-`zvm` uses `uname` to detect the target and it currently only uses what `uname`
-provides, which will differ depending on the Linux subsystem used (git-bash,
-WSL, mingw, etc). However, [Zig's
-targets](https://ziglang.org/documentation/master/std/#std.Target.Os.Tag) use
-`windows` as the OS name. Due to this, for now you'll have to explicitly set
-your target:
-
-```shell
-zvm --target <arch>-windows
-```
-
-Replace `<arch>` with one of the following:
-- On a 32-bit system, `x86` (e.g. `x86-windows`)
-- On a 64-bit x86 system, `x86-64` (e.g. `x86_64-windows`)
-- On a 64-bit aarch64 system, aarch64 (e.g. `aarch64-windows`)
+Windows is not natively supported. However, support exists for WSL2 and
+`git-bash`.
 
 ### MacOS
 
-Supported natively but shares the same gotchas as the Windows support.
+I have no idea if `zvm` works on MacOS or not. If you're using MacOS and would
+like to help bring official support to MacOS, please submit a PR! With that
+said, as long as the dependencies exist, MacOS should be supported. You may
+need to manually specify your target.
 
 `zvm` uses `uname` to detect the target and it currently only uses what `uname`
 provides. However, [Zig's

--- a/completions/zvm-completions.bash
+++ b/completions/zvm-completions.bash
@@ -8,7 +8,7 @@ _zvm_completions()
     commands="help install list prune uninstall use"
     global_options="-h --help -t --target -v -vv --verbose"
     list_options="-i --installed"
-    install_options="-e --exact -u --use"
+    install_options="-e --exact -s --src -u --use"
     uninstall_options="-f --force -l --use-latest"
 
     zvm_local_versions="$(zvm list --installed)"

--- a/completions/zvm-completions.zsh
+++ b/completions/zvm-completions.zsh
@@ -44,6 +44,7 @@ zvm_list_options=(
 
 zvm_install_options=(
     '(-e,--exact)'{-e,--exact}"[Attempt to install version, even if it doesn't exist in remote index]"
+    '(-s,--src)'{-s,--src}'[Build from source]'
     '(-u,--use)'{-u,--use}'[Make version active after installing]'
 )
 

--- a/zvm
+++ b/zvm
@@ -310,6 +310,35 @@ file_download_no_checksum() {
 }
 
 ################################################################################
+# Source functions                                                             #
+################################################################################
+src_build() {
+    _ref="master"
+    cpus=$(sed -nr 's/siblings\s+: ([0-9]+)/\1/p' /proc/cpuinfo | head -n 1)
+
+    src_path="${ZVM_HOME}/src"
+
+    if [ -d "$src_path" ]; then
+        vrb "checking out ${_ref}"
+        git -C "$src_path" switch -d -q origin/master
+    else
+        vrb "cloning https://github.com/ziglang/zig#${_ref}"
+        git clone -b "$_ref" -n -o origin -q https://github.com/ziglang/zig "$src_path"
+    fi
+
+    vrb "pulling https://github.com/ziglang/zig#${_ref}"
+    git -C "$src_path" pull -q origin "$_ref"
+
+    vrb "configuring build with cmake"
+    cmake -S "$src_path" -B "${src_path}/build" > /dev/null
+
+    vrb2 "building zig with ${cpus} jobs"
+    cmake --build "${src_path}/build" -- -j "$cpus"
+
+    "${src_path}/build/stage3/bin/zig" version
+}
+
+################################################################################
 # Command functions                                                            #
 ################################################################################
 
@@ -386,14 +415,18 @@ cmd_use() {
 # options:
 #   -e, --exact  Attempt to install version, even if it doesn't exist in the
 #                index
-#   -u, --use    Make active immediately after install
-o_exact=0
+#   -s, --src  Build from source
+#   -u, --use  Make active immediately after install
+o_src=0
 o_use=0
 cmd_install() {
     for arg in "$@"; do
         case $1 in
             -e|--exact)
                 o_exact=1
+                ;;
+            -s|--src)
+                o_src=1
                 shift
                 ;;
             -u|--use)
@@ -405,6 +438,11 @@ cmd_install() {
 
     _version=$1
     index_version=$_version
+
+    if [ $o_src -eq 1 ]; then
+        src_build
+        return 0
+    fi
 
     if [ "${_version}" = 'master' ]; then
         _version=$(index_get_master_version)

--- a/zvm
+++ b/zvm
@@ -586,6 +586,7 @@ Commands:
   install [OPTIONS] <version>    Install a Zig version
     -e, --exact                  Attempt to install version, even if it doesn't
                                  exist in the remote index
+    -s, --src                    Build from source
     -u, --use                    Make version active immediately
 
   use <version>                  Use an installed Zig version

--- a/zvm
+++ b/zvm
@@ -417,6 +417,7 @@ cmd_use() {
 #                index
 #   -s, --src  Build from source
 #   -u, --use  Make active immediately after install
+o_exact=0
 o_src=0
 o_use=0
 cmd_install() {


### PR DESCRIPTION
Add `-s,--src` flag to the install command that allows building Zig [from source](https://github.com/ziglang/zig/wiki/Building-Zig-From-Source#option-a-use-your-system-installed-build-tools).